### PR TITLE
Use the local proxy when reaching the backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "deploy": "npm-run-all build:prod lint test",
     "verify": "npm-run-all build lint test",
     "nightly": "npm run deploy",
-    "proxy": "SPANDX_CONFIG=\"./profiles/local-frontend.js\" bash $PROXY_PATH/scripts/run.sh"
+    "proxy": "SPANDX_CONFIG=\"./profiles/local-frontend-and-api.js\" bash $PROXY_PATH/scripts/run.sh"
   },
   "insights": {
     "appname": "custom-policies"

--- a/profiles/local-frontend-and-api.js
+++ b/profiles/local-frontend-and-api.js
@@ -1,9 +1,9 @@
 /*global module*/
 
 const SECTION = 'insights';
-const APP_ID = 'starter';
+const APP_ID = 'custom-policies';
 const FRONTEND_PORT = 8002;
-const API_PORT = 8888;
+const API_PORT = 8080;
 const routes = {};
 
 routes[`/beta/${SECTION}/${APP_ID}`] = { host: `https://localhost:${FRONTEND_PORT}` };
@@ -11,6 +11,10 @@ routes[`/${SECTION}/${APP_ID}`]      = { host: `https://localhost:${FRONTEND_POR
 routes[`/beta/apps/${APP_ID}`]       = { host: `https://localhost:${FRONTEND_PORT}` };
 routes[`/apps/${APP_ID}`]            = { host: `https://localhost:${FRONTEND_PORT}` };
 
-routes[`/api/${APP_ID}`] = { host: `https://localhost:${API_PORT}` };
+// For testing a new menu, see:
+// https://github.com/RedHatInsights/cloud-services-config#testing-your-changes-locally
+routes[`/beta/config`]               = { host: `http://localhost:8889` };
+
+routes[`/api/v1/policies`] = { host: `http://localhost:${API_PORT}` };
 
 module.exports = { routes };

--- a/src/pages/AddCustomPolicyPage.tsx
+++ b/src/pages/AddCustomPolicyPage.tsx
@@ -25,7 +25,7 @@ type AddPageState = {
 
 class AddCustomPolicyPage extends React.Component<AddPageProps, AddPageState> {
 
-    API = 'http://localhost:8080/api/v1/policies/';
+    API = '/api/v1/policies/';
 
     constructor(props: AddPageProps) {
         super(props);

--- a/src/pages/ListPage/ListPage.tsx
+++ b/src/pages/ListPage/ListPage.tsx
@@ -16,7 +16,7 @@ type ListPageState = {
 
 class ListPage extends React.Component<ListPageProps, ListPageState> {
 
-    API = 'http://localhost:8080/api/v1/policies/';
+    API = '/api/v1/policies/';
 
     constructor(props: ListPageProps) {
         super(props);


### PR DESCRIPTION
Configures the proxy to map requests from `/api/v1/policies` to ``http://localhost:8080/api/v1/policies`