### PR TITLE
Add code to read actions, verify+store, deletion from the list page.

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,16 +1,30 @@
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router';
 import { Routes } from '../Routes';
+import { CpCxProvider } from '../utils/CPContext';
 
 declare const insights: any;
 
 class App extends React.PureComponent<RouteComponentProps> {
 
     appNav: any;
+    state: {
+        accountNumber: string;
+        username: string;
+    } = { accountNumber: '', username: '' };
 
     componentDidMount() {
         insights.chrome.init();
         insights.chrome.identifyApp('custom-policies');
+        insights.chrome.auth.getUser().then((value: any) =>
+        {
+            console.log('App auth data ' + value.identity.account_number);
+            // this.context.accountNumber = value.identity.account_number;
+            // this.context.username = value.identity.user.username;
+            this.setState({ accountNumber: value.identity.account_number,
+                username: value.identity.user.username });
+
+        });
         this.appNav = insights.chrome.on('APP_NAVIGATION', (event: any) => this.props.history.push(`/${event.navId}`));
     }
 
@@ -20,7 +34,9 @@ class App extends React.PureComponent<RouteComponentProps> {
 
     render() {
         return (
-            <Routes/>
+            <CpCxProvider value={ this.state } >
+                <Routes/>
+            </CpCxProvider>
         );
     }
 

--- a/src/pages/AddCustomPolicyPage.tsx
+++ b/src/pages/AddCustomPolicyPage.tsx
@@ -16,6 +16,7 @@ import { PageHeader, Main, Section, PageHeaderTitle } from '@redhat-cloud-servic
 import { Policy } from '../types/Policy';
 import { Link } from 'react-router-dom';
 import { createPolicy, verifyPolicy } from '../services/Api';
+import CpContext from '../utils/CPContext';
 
 type AddPageProps = {};
 type AddPageState = {
@@ -34,12 +35,14 @@ class AddCustomPolicyPage extends React.Component<AddPageProps, AddPageState> {
     possibleActions = [ 'email', 'webhook', 'sms' ];
     actionHints = [ 'email address', 'target URL', 'phone number' ];
 
+    static contextType = CpContext;
+
     constructor(props: AddPageProps) {
         super(props);
         this.state = {
             isValid: false,
             policy: {
-                customerid: '1',
+                customerid: this.context.accountNumber,
                 conditions: '',
                 name: '',
                 isEnabled: false },
@@ -209,7 +212,7 @@ class AddCustomPolicyPage extends React.Component<AddPageProps, AddPageState> {
         this.setState({
             ddOpen: ddState
         });
-    }
+    };
 
     toggleAction(name: string, value: boolean, key: number) {
         console.log(name + ' - ' + value + ' - ' + key);

--- a/src/pages/AddCustomPolicyPage.tsx
+++ b/src/pages/AddCustomPolicyPage.tsx
@@ -15,16 +15,22 @@ import { PageHeader, Main, Section, PageHeaderTitle } from '@redhat-cloud-servic
 
 import { Policy } from '../types/Policy';
 import { Link } from 'react-router-dom';
-import { createPolicy } from '../services/Api';
+import { createPolicy, verifyPolicy } from '../services/Api';
 
 type AddPageProps = {};
 type AddPageState = {
     policy: Policy;
     isValid: boolean;
+    filled: boolean;
+    messages: string;
     ddOpen: boolean;
+    checkStates: boolean[];
+    actionProps: string[];
 };
 
 class AddCustomPolicyPage extends React.Component<AddPageProps, AddPageState> {
+
+    possibleActions = [ 'email', 'webhook', 'sms', 'slack' ];
 
     constructor(props: AddPageProps) {
         super(props);
@@ -35,11 +41,28 @@ class AddCustomPolicyPage extends React.Component<AddPageProps, AddPageState> {
                 conditions: '',
                 name: '',
                 isEnabled: false },
-            ddOpen: false
+            ddOpen: false,
+            filled: false,
+            messages: '',
+            checkStates: new Array(this.possibleActions.length),
+            actionProps: new Array(this.possibleActions.length)
         };
     }
 
     render() {
+        const actionCheck = this.possibleActions.map((action, key) =>
+
+            <FormGroup fieldId={ 'action-' + key } label={ action } isRequired={ false }  >
+                <Checkbox id={ 'check-' + key } label={ action }
+                    onChange={ value => this.toggleAction(action, value, key) }
+                    isChecked={ this.state.checkStates[key] } />
+                <TextInput id={ 'action-ti-' + key }
+                    value={ this.state.actionProps[key] }
+                    isDisabled={ !this.state.checkStates[key] }
+                    onChange= { value => this.actionsOnChangeHandler(key, value) }/>
+            </FormGroup>
+        );
+
         return (
             <>
                 <PageHeader>
@@ -61,28 +84,26 @@ class AddCustomPolicyPage extends React.Component<AddPageProps, AddPageState> {
                             <FormGroup
                                 fieldId='description'
                                 label='Description'>
-                                <TextInput id={ 'description' } placeholder='A short description'/>
+                                <TextInput id={ 'description' }
+                                    onChange={ value => this.onChangeHandler(-1, 'description', value) }
+                                    placeholder='A short description'/>
                             </FormGroup>
                             <FormGroup
-                                fieldId='rule'
-                                label='Rule text'
+                                fieldId='conditions'
+                                label='Condition text'
                                 isRequired={ true }
                             >
-                                <TextInput id={ 'rule' } placeholder='"a"== "b"'/>
+                                <TextInput id={ 'conditions' }
+                                    placeholder='"a"== "b"'
+                                    onChange={ value => this.onChangeHandler(-1, 'conditions', value) }/>
                             </FormGroup>
                             <FormGroup fieldId={ 'isActive' } label={ 'Enabled?' }>
                                 <Checkbox id={ 'isActive' } default={ false }/>
                             </FormGroup>
-                            <FormGroup fieldId={ 'action' } label='Actions' >
-                                <Checkbox id='check-email' label={ 'Email' }/>
-                                <Checkbox id={ 'check-webhook' } label={ 'Webhook' }/>
-                                <Checkbox id={ 'check-sms' } label={ 'SMS' }/>
-                                <Checkbox id={ 'check-slack' } label={ 'Slack' }/>
-                                <TextInput id={ 'action param' }/>
-                            </FormGroup>
+                            { actionCheck }
                             <FormGroup fieldId={ 'severity' } label={ 'Severity' } >
                                 <Dropdown
-                                    toggle={ <DropdownToggle onToggle={ this.onToggle }>Actions</DropdownToggle> }
+                                    toggle={ <DropdownToggle onToggle={ this.onToggle }>Severity</DropdownToggle> }
                                     position={ DropdownPosition.right }
                                     isOpen={ this.state.ddOpen }
                                     label={ 'Severity' }
@@ -95,11 +116,18 @@ class AddCustomPolicyPage extends React.Component<AddPageProps, AddPageState> {
                                     ] }
                                 />
                             </FormGroup>
+                            <FormGroup fieldId={ 'msg' } label={ 'Messages' }>
+                                <TextInput isDisabled={ true } id={ 'msg' } value={ this.state.messages } type={ 'text' }/>
+                            </FormGroup>
                             <ActionGroup>
                                 <Link to='/list' className={ 'btn btn-secondary' }>Back</Link>
                                 {/*<Button key={ 'back' } variant={ 'link' } onClick={ this.cancel }>Cancel</Button>*/}
-                                <Button key={ 'create' } variant={ 'secondary' } isDisabled={ !this.state.isValid }>Create</Button>
-                                <Button key={ 'test' } variant={ 'primary' } onClick={ this.testPolicy }>Test</Button>
+                                <Button key={ 'create' } variant={ 'secondary' }
+                                    isDisabled={ !this.state.isValid }
+                                    onClick={ this.storePolicy }>Create</Button>
+                                <Button key={ 'verify' } variant={ 'primary' }
+                                    isDisabled={ !this.state.filled }
+                                    onClick={ this.testPolicy }>Verify</Button>
                             </ActionGroup>
                         </Form>
                     </Section>
@@ -115,11 +143,23 @@ class AddCustomPolicyPage extends React.Component<AddPageProps, AddPageState> {
     };
 
     testPolicy = () => {
-        createPolicy(this.state.policy)
-        .then(() => this.setState({ isValid: true }))
+        this.fillActions();
+        verifyPolicy(this.state.policy)
+        .then(() => this.setState({ isValid: true, messages: 'Policy is valid' }))
         .catch(reason  => {
             console.log(reason);
-            this.setState({ isValid: false });
+            this.setState({ isValid: false, messages: reason });
+        });
+
+    };
+
+    storePolicy = () => {
+        this.fillActions();
+        createPolicy(this.state.policy)
+        .then(() => this.setState({ isValid: true, messages: 'Policy stored' }))
+        .catch(reason  => {
+            console.log(reason);
+            this.setState({ isValid: false, messages: reason });
         });
 
     };
@@ -127,18 +167,32 @@ class AddCustomPolicyPage extends React.Component<AddPageProps, AddPageState> {
     onChangeHandler(selectedId: number, field: string, value: string) {
         this.setState(prevState => {
             const tmp = prevState.policy;
+            let fill = prevState.filled;
             if (selectedId === -1) {
                 switch (field) {
                     case 'name':
                         tmp.name = value.trim();
+                        break;
+                    case 'description':
+                        tmp.description = value.trim();
+                        break;
+                    case 'conditions':
+                        tmp.conditions = value.trim();
                         break;
                     default:
                         console.log('TODO');
                 }
             }
 
+            if (tmp.name && tmp.conditions) {
+                fill = true;
+            } else {
+                fill = false;
+            }
+
             return {
-                policy: tmp
+                policy: tmp,
+                filled: fill
             };
         });
     }
@@ -149,6 +203,40 @@ class AddCustomPolicyPage extends React.Component<AddPageProps, AddPageState> {
         });
     }
 
-}
+    toggleAction(name: string, value: boolean, key: number) {
+        console.log(name + ' - ' + value + ' - ' + key);
+        this.setState(prevState => {
+            const tmp = prevState.checkStates;
+            tmp[key] = !tmp[key];
+
+            return { checkStates: tmp };
+        });
+    }
+
+    actionsOnChangeHandler(key: number, value: string) {
+        this.setState(prevState => {
+            const tmp = prevState.actionProps;
+            tmp[key] = value.trim();
+
+            return { actionProps: tmp };
+        })    ;
+    }
+
+    fillActions() {
+        this.setState(prevState => {
+            let tmp = '';
+            const oldPol = prevState.policy;
+            this.possibleActions.map ((action, key) =>
+            {
+                if (this.state.checkStates[key]) {
+                    tmp = tmp + action.toUpperCase() + ' ' + this.state.actionProps[key] + ';';
+                }
+            });
+            oldPol.actions = tmp;
+            return { policy: oldPol };
+        });
+    };
+
+};
 
 export default AddCustomPolicyPage;

--- a/src/pages/ListPage/ListPage.tsx
+++ b/src/pages/ListPage/ListPage.tsx
@@ -6,6 +6,7 @@ import { PageHeader, Main, Section, PageHeaderTitle } from '@redhat-cloud-servic
 import { Policy } from '../../types/Policy';
 import { Link } from 'react-router-dom';
 import { deletePolicy, getPolicies } from '../../services/Api';
+import CpContext from '../../utils/CPContext';
 
 type ListPageProps = {};
 type ListPageState = {
@@ -17,6 +18,8 @@ type ListPageState = {
 };
 
 class ListPage extends React.Component<ListPageProps, ListPageState> {
+
+    static contextType = CpContext;
 
     constructor(props: ListPageProps) {
         super(props);
@@ -95,14 +98,14 @@ class ListPage extends React.Component<ListPageProps, ListPageState> {
     }
 
     componentDidMount() {
-        const customerId = '1';
+        const customerId = this.context.accountNumber;
         getPolicies(customerId)
         .then(response => response.data)
         .then(data => this.setState({ rawData: data, needsUpdate: false }));
     }
 
     deletePolicy(cell: any) {
-        const customerId = '1';
+        const customerId = this.context.accountNumber;
         deletePolicy(customerId, cell)
         .then(response => response.status)
         .then(data => {

--- a/src/pages/ListPage/ListPage.tsx
+++ b/src/pages/ListPage/ListPage.tsx
@@ -105,8 +105,10 @@ class ListPage extends React.Component<ListPageProps, ListPageState> {
         const customerId = '1';
         deletePolicy(customerId, cell)
         .then(response => response.status)
-        .then((data => { alert('Code: ' + data);
-            this.setState ({ needsUpdate: true });}));
+        .then(data => {
+            alert('Code: ' + data);
+            this.setState ({ needsUpdate: true });
+        });
     }
 }
 

--- a/src/pages/ListPage/ListPage.tsx
+++ b/src/pages/ListPage/ListPage.tsx
@@ -5,7 +5,7 @@ import { CheckCircleIcon,  PlusCircleIcon } from '@patternfly/react-icons';
 import { PageHeader, Main, Section, PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
 import { Policy } from '../../types/Policy';
 import { Link } from 'react-router-dom';
-import { getPolicies } from '../../services/Api';
+import { deletePolicy, getPolicies } from '../../services/Api';
 
 type ListPageProps = {};
 type ListPageState = {
@@ -13,6 +13,7 @@ type ListPageState = {
     rows: IRow[];
     actions: IActions;
     rawData: Policy[];
+    needsUpdate: boolean;
 };
 
 class ListPage extends React.Component<ListPageProps, ListPageState> {
@@ -22,7 +23,7 @@ class ListPage extends React.Component<ListPageProps, ListPageState> {
 
         this.state = {
             columns: [
-                'Name', 'Description', 'Conditions', 'Actions', 'Is active?'
+                'id', 'Name', 'Description', 'Conditions', 'Actions', 'Is active?'
             ],
             rows: [],
             actions: [
@@ -36,10 +37,16 @@ class ListPage extends React.Component<ListPageProps, ListPageState> {
                 },
                 {
                     title: 'Delete',
-                    onClick: () => alert('Delete')
+                    onClick: (event, rowId, rowData) => {
+                        alert('Delete ' + rowId + ' : ' + rowData.cells);
+                        if (rowData.cells) {
+                            this.deletePolicy(rowData.cells[0]);
+                        }
+                    }
                 }
             ],
-            rawData: []
+            rawData: [],
+            needsUpdate: false
         };
     }
 
@@ -52,6 +59,7 @@ class ListPage extends React.Component<ListPageProps, ListPageState> {
             this.state.rawData.map(value =>
                 rows.push({
                     cells: [
+                        value.id,
                         value.name,
                         value.description,
                         value.conditions,
@@ -90,9 +98,16 @@ class ListPage extends React.Component<ListPageProps, ListPageState> {
         const customerId = '1';
         getPolicies(customerId)
         .then(response => response.data)
-        .then(data => this.setState({ rawData: data }));
+        .then(data => this.setState({ rawData: data, needsUpdate: false }));
     }
 
+    deletePolicy(cell: any) {
+        const customerId = '1';
+        deletePolicy(customerId, cell)
+        .then(response => response.status)
+        .then((data => { alert('Code: ' + data);
+            this.setState ({ needsUpdate: true });}));
+    }
 }
 
 export default ListPage;

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -17,6 +17,8 @@ export const getFacts = () => newRequest<Fact[]>('GET', urls.facts);
 
 export const getPolicies = (customerId: string) => newRequest<Policy[]>('GET', urls.policies(customerId));
 
-export const createPolicy = (policy: Policy) => newRequest<void>('POST', urls.policies(policy.customerid), {}, policy);
+export const createPolicy = (policy: Policy) => newRequest<void>('POST', urls.policies(policy.customerid), { alsoStore: true }, policy);
+export const verifyPolicy = (policy: Policy) => newRequest<void>('POST', urls.policies(policy.customerid), {}, policy);
 
 export const getCustomerPolicy = (customerId: string, policyId: string) => newRequest<Policy>('GET', urls.customerPolicy(customerId, policyId));
+export const deletePolicy = (customerId: string, policyId: string) => newRequest<Policy>('DELETE', urls.customerPolicy(customerId, policyId));

--- a/src/utils/CPContext.ts
+++ b/src/utils/CPContext.ts
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+/*
+ * A context to be used to pass stuff around. May later be replaced by a better
+ * solution
+ */
+
+const CpContext = React.createContext({ username: '', accountNumber: '' });
+CpContext.displayName = 'CPContext';
+
+export const CpCxProvider = CpContext.Provider;
+export const CpCxConsumer = CpContext.Consumer;
+export default CpContext;


### PR DESCRIPTION
With this code it is possible to round-trip : create a new policy, verify+store it, have it shown in the list and delete it again. See https://youtu.be/Zemnrh29esc

This needs https://github.com/RedHatInsights/custom-policies-ui-backend/pull/6

Signed-off-by: Heiko W. Rupp <hrupp@redhat.com>