### PR TITLE
CPOL-57 Validate the conditions with the ui-backend

### DIFF
--- a/src/components/Policy/PolicyWizard.tsx
+++ b/src/components/Policy/PolicyWizard.tsx
@@ -66,8 +66,8 @@ const enableNext = (isValid: boolean, isLoading: boolean) => {
 };
 
 const isStepValid = (step: WizardStepExtended, wizardContext: Omit<WizardContext, 'isValid'>, values: FormType) => {
-    if (step.isContextValid) {
-        return step.isContextValid(wizardContext, values);
+    if (step.isValid) {
+        return step.isValid(wizardContext, values);
     }
 
     return wizardContext.isFormValid;

--- a/src/components/Policy/PolicyWizard.tsx
+++ b/src/components/Policy/PolicyWizard.tsx
@@ -1,10 +1,15 @@
 import * as React from 'react';
 import { Form, Wizard, WizardStepFunctionType } from '@patternfly/react-core';
-import { Formik, FormikHelpers, FormikProps } from 'formik';
-import { DeepPartial } from 'ts-essentials';
+import { Formik, FormikHelpers, useFormikContext } from 'formik';
 
 import { Policy } from '../../types/Policy';
-import { WizardStepExtended } from './WizardSteps/WizardStepExtended';
+import {
+    FormType,
+    VerifyPolicyResponse,
+    WizardActionType,
+    WizardContext,
+    WizardStepExtended
+} from './PolicyWizardTypes';
 import { createCustomPolicyStep } from './WizardSteps/CreateCustomPolicyStep';
 import { createDetailsStep } from './WizardSteps/DetailsStep';
 import { createConditionsStep } from './WizardSteps/ConditionsStep';
@@ -13,22 +18,15 @@ import { createReviewStep } from './WizardSteps/ReviewStep';
 import { PolicyFormSchema } from '../../schemas/CreatePolicy/PolicySchema';
 import { PolicyWizardFooter } from './PolicyWizardFooter';
 
-type FormType = DeepPartial<Policy>;
-
-enum SubmitActionEnum {
-    SAVE = 'CREATE',
-    VERIFY = 'VERIFY',
-    NONE = 'NONE'
-}
-
 interface PolicyWizardProps {
     initialValue: FormType;
     onClose: () => void;
     onSave: (policy: Policy) => void;
+    onVerify: (policy: Policy) => Promise<VerifyPolicyResponse>;
     isLoading: boolean;
 }
 
-const buildSteps: (props: PolicyWizardProps) => WizardStepExtended[] = (props) => {
+const buildSteps: () => WizardStepExtended[] = () => {
     return [
         createCustomPolicyStep({
             hideBackButton: true
@@ -38,7 +36,7 @@ const buildSteps: (props: PolicyWizardProps) => WizardStepExtended[] = (props) =
         }),
         createConditionsStep(),
         createActionsStep(),
-        createReviewStep(props.isLoading, {
+        createReviewStep({
             nextButtonText: 'Finish'
         })
     ].map((step, index) => ({
@@ -67,11 +65,91 @@ const enableNext = (isValid: boolean, isLoading: boolean) => {
     return !isLoading && isValid;
 };
 
+const isStepValid = (step: WizardStepExtended, wizardContext: Omit<WizardContext, 'isValid'>, values: FormType) => {
+    if (step.isContextValid) {
+        return step.isContextValid(wizardContext, values);
+    }
+
+    return wizardContext.isFormValid;
+};
+
+interface FormikBindingProps {
+    currentStep: number;
+    maxStep: number;
+    isLoading: boolean;
+    submitAction: WizardActionType;
+    setSubmitAction: (action: WizardActionType) => void;
+    steps: WizardStepExtended[];
+    verifyResponse: VerifyPolicyResponse;
+    onMove: WizardStepFunctionType;
+    onClose: () => void;
+}
+
+const FormikBinding: React.FunctionComponent<FormikBindingProps> = (props) => {
+
+    const formikProps = useFormikContext<FormType>();
+
+    React.useEffect(() => {
+        formikProps.validateForm();
+    }, [ props.currentStep ]);
+
+    React.useEffect(() => {
+        if (props.submitAction !== WizardActionType.NONE) {
+            formikProps.handleSubmit();
+        }
+    }, [ props.submitAction ]);
+
+    const wizardContext: WizardContext = {
+        isLoading: props.isLoading,
+        isFormValid: formikProps.isValid,
+        triggerAction: props.setSubmitAction,
+        verifyResponse: props.verifyResponse
+    };
+
+    const isValid = isStepValid(props.steps[props.currentStep], wizardContext, formikProps.values);
+    wizardContext.isValid = isValid;
+
+    const stepsValidated = props.steps.map(step => ({
+        ...step,
+        enableNext: enableNext(isValid, props.isLoading),
+        canJumpTo: canJumpTo(step.id as number, isValid, props.currentStep, props.maxStep, props.isLoading)
+    }));
+
+    const onSave = () => {
+        props.setSubmitAction(WizardActionType.SAVE);
+    };
+
+    return (
+        <Form>
+            <WizardContext.Provider value={ wizardContext }>
+                <Wizard
+                    isOpen={ true }
+                    onSave={ onSave }
+                    onClose={ props.onClose }
+                    steps={ stepsValidated }
+                    startAtStep={ props.currentStep + 1 } // Wizard steps starts at 1
+                    onNext={ props.onMove }
+                    onBack={ props.onMove }
+                    onGoToStep={ props.onMove }
+                    title="Add Custom Policy"
+                    description={ 'Custom policies are processed on reception of system profile messages. ' +
+                    'If condition(s) are met, defined action(s) are triggered.' }
+                    footer={ <PolicyWizardFooter loadingText="Loading"  isLoading={ props.isLoading }/> }
+                />
+            </WizardContext.Provider>
+        </Form>
+    );
+};
+
 export const PolicyWizard: React.FunctionComponent<PolicyWizardProps> = (props: PolicyWizardProps) => {
 
     const [ currentStep, setCurrentStep ] = React.useState<number>(0);
     const [ maxStep, setMaxStep ] = React.useState<number>(0);
-    const [ submitAction, setSubmitAction ] = React.useState<SubmitActionEnum>(SubmitActionEnum.NONE);
+    const [ submitAction, setSubmitAction ] = React.useState<WizardActionType>(WizardActionType.NONE);
+    const [ verifyResponse, setVerifyResponse ] =
+    React.useState<VerifyPolicyResponse>({
+        isValid: false
+    });
 
     const onMove: WizardStepFunctionType = (current, _previous) => {
         const currentStep = current.id as number;
@@ -81,74 +159,47 @@ export const PolicyWizard: React.FunctionComponent<PolicyWizardProps> = (props: 
         }
     };
 
-    const steps: WizardStepExtended[] = buildSteps(props);
+    const steps: WizardStepExtended[] = buildSteps();
 
     const onSubmit = (policy: FormType, formikHelpers: FormikHelpers<FormType>) => {
         formikHelpers.setSubmitting(false);
 
-        setSubmitAction(SubmitActionEnum.NONE);
+        setSubmitAction(WizardActionType.NONE);
+        const transformedPolicy = PolicyFormSchema.cast(policy) as Policy;
+        formikHelpers.setValues(transformedPolicy);
         switch (submitAction) {
-            case SubmitActionEnum.SAVE:
-                props.onSave(PolicyFormSchema.cast(policy) as Policy);
+            case WizardActionType.SAVE:
+                props.onSave(transformedPolicy);
                 break;
-            case SubmitActionEnum.VERIFY:
-                console.log('Nothing hooked to VERIFY yet...');
+            case WizardActionType.VERIFY:
+                props.onVerify(transformedPolicy).then(setVerifyResponse);
                 break;
             default:
                 throw new Error('Unexpected action');
         }
     };
 
-    const FormikBinding = (formikProps: FormikProps<FormType>) => {
-        React.useEffect(() => {
-            formikProps.validateForm();
-        }, [ currentStep ]);
-
-        React.useEffect(() => {
-            if (submitAction !== SubmitActionEnum.NONE) {
-                formikProps.handleSubmit();
-            }
-        }, [ submitAction ]);
-
-        const stepsValidated = steps.map(step => ({
-            ...step,
-            enableNext: enableNext(formikProps.isValid, props.isLoading),
-            canJumpTo: canJumpTo(step.id as number, formikProps.isValid, currentStep, maxStep, props.isLoading)
-        }));
-
-        const onSave = () => {
-            setSubmitAction(SubmitActionEnum.SAVE);
-        };
-
-        return (
-            <Form>
-                <Wizard
-                    isOpen={ true }
-                    onSave={ onSave }
-                    onClose={ props.onClose }
-                    steps={ stepsValidated }
-                    startAtStep={ currentStep + 1 } // Wizard steps starts at 1
-                    onNext={ onMove }
-                    onBack={ onMove }
-                    onGoToStep={ onMove }
-                    title="Add Custom Policy"
-                    description={ 'Custom policies are processed on reception of system profile messages. ' +
-                    'If condition(s) are met, defined action(s) are triggered.' }
-                    footer={ <PolicyWizardFooter loadingText="Saving"  isLoading={ props.isLoading }/> }
-                />
-            </Form>
-        );
-    };
-
     return (
         <>
             <Formik<FormType>
                 initialValues={ props.initialValue }
-                component={ FormikBinding }
-                validateOnMount={ true }
+                initialStatus={ {} }
+                validateOnMount={ false }
                 validationSchema={ steps[currentStep].validationSchema }
                 onSubmit={ onSubmit }
-            />
+            >
+                <FormikBinding
+                    currentStep={ currentStep }
+                    maxStep={ maxStep }
+                    isLoading={ props.isLoading }
+                    submitAction={ submitAction }
+                    setSubmitAction={ setSubmitAction }
+                    steps={ steps }
+                    verifyResponse={ verifyResponse }
+                    onClose={ props.onClose }
+                    onMove={ onMove }
+                />
+            </Formik>
         </>
     );
 };

--- a/src/components/Policy/PolicyWizardFooter.tsx
+++ b/src/components/Policy/PolicyWizardFooter.tsx
@@ -4,9 +4,15 @@ import {
     WizardFooter,
     WizardContextConsumer,
     WizardStep,
-    ButtonVariant, Bullseye
+    ButtonVariant
 } from '@patternfly/react-core';
 import { Spinner } from '@patternfly/react-core/dist/js/experimental';
+import { style } from 'typestyle';
+
+const loadingClassName = style({
+    marginTop: 'auto',
+    marginBottom: 14
+});
 
 // Copied from: https://github.com/patternfly/patternfly-react/blob/master/packages/patternfly-4/react-core/src/components/Wizard/Wizard.tsx#L451-L457
 // Todo: https://github.com/patternfly/patternfly-react/issues/3545
@@ -56,10 +62,10 @@ export const PolicyWizardFooter: React.FunctionComponent<PolicyWizardFooterProps
                                 </Button>
                             )}
                             { props.isLoading && (
-                                <Bullseye>
+                                <div className={ loadingClassName }>
                                     { props.loadingText } &nbsp;
                                     <Spinner size="md" />
-                                </Bullseye>
+                                </div>
                             )}
                         </>
                     );

--- a/src/components/Policy/PolicyWizardTypes.ts
+++ b/src/components/Policy/PolicyWizardTypes.ts
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import * as Yup from 'yup';
+
+import { WizardStep } from '@patternfly/react-core';
+import { DeepPartial, DeepReadonly } from 'ts-essentials';
+import { Policy } from '../../types/Policy';
+
+export type FormType = DeepPartial<Policy>;
+
+export type WizardStepExtended = WizardStep & {
+  validationSchema: Yup.Schema<unknown>;
+  isContextValid?: (context: WizardContext, values: DeepReadonly<FormType>) => boolean;
+};
+
+export const AlwaysValid = Yup.object();
+
+export enum WizardActionType {
+  SAVE = 'CREATE',
+  VERIFY = 'VERIFY',
+  NONE = 'NONE'
+}
+
+export interface VerifyPolicyResponse {
+    isValid: boolean;
+    error?: string;
+    conditions?: string;
+}
+
+export interface WizardContext {
+  isLoading: boolean;
+  isFormValid: boolean;
+  isValid?: boolean;
+  triggerAction: (action: WizardActionType) => void;
+  verifyResponse: VerifyPolicyResponse;
+}
+
+export const WizardContext = React.createContext<WizardContext>({
+    isLoading: false,
+    isFormValid: false,
+    triggerAction: () => {
+        throw Error('Action executed without WizardContext');
+    },
+    verifyResponse: {
+        isValid: false
+    }
+});

--- a/src/components/Policy/PolicyWizardTypes.ts
+++ b/src/components/Policy/PolicyWizardTypes.ts
@@ -9,7 +9,7 @@ export type FormType = DeepPartial<Policy>;
 
 export type WizardStepExtended = WizardStep & {
   validationSchema: Yup.Schema<unknown>;
-  isContextValid?: (context: WizardContext, values: DeepReadonly<FormType>) => boolean;
+  isValid?: (context: WizardContext, values: DeepReadonly<FormType>) => boolean;
 };
 
 export const AlwaysValid = Yup.object();

--- a/src/components/Policy/WizardSteps/ActionsStep.tsx
+++ b/src/components/Policy/WizardSteps/ActionsStep.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Form } from '@patternfly/react-core';
 
-import { WizardStepExtended } from './WizardStepExtended';
+import { WizardStepExtended } from '../PolicyWizardTypes';
 import { PolicyFormActions } from '../../../schemas/CreatePolicy/PolicySchema';
 import { FieldArray, FieldArrayRenderProps } from 'formik';
 import { ActionsForm } from '../ActionsForm';

--- a/src/components/Policy/WizardSteps/ConditionsStep.tsx
+++ b/src/components/Policy/WizardSteps/ConditionsStep.tsx
@@ -1,16 +1,79 @@
 import * as React from 'react';
-import { Form } from '@patternfly/react-core';
+import { ActionGroup, Button, ButtonVariant, Form } from '@patternfly/react-core';
+import { ExclamationCircleIcon, CheckCircleIcon } from '@patternfly/react-icons';
 
 import { FormTextInput } from '../../Formik/Patternfly';
-import { WizardStepExtended } from './WizardStepExtended';
+import { FormType, WizardActionType, WizardContext, WizardStepExtended } from '../PolicyWizardTypes';
 import { PolicyFormConditions } from '../../../schemas/CreatePolicy/PolicySchema';
+import { useFormikContext } from 'formik';
+import { style } from 'typestyle';
+import { GlobalDangerColor100, GlobalSuccessColor200 } from '../../../utils/PFColors';
 
-const ConditionsStep = () => {
+const centerClassName = style({
+    marginTop: 'auto',
+    marginBottom: 'auto'
+});
+
+interface ConditionStatusProps {
+    isValid?: boolean;
+    error?: string;
+    changed?: boolean;
+}
+
+const ConditionStatus: React.FunctionComponent<ConditionStatusProps> = (props) => {
+    if (props.changed) {
+        return null;
+    }
+
+    if (props.isValid) {
+        return (
+            <>
+                <CheckCircleIcon className={ centerClassName } color={ GlobalSuccessColor200 }/>
+                <div className={ centerClassName }>Condition is valid</div>
+            </>
+        );
+    }
+
+    if (props.error) {
+        return (
+            <>
+                <ExclamationCircleIcon className={ centerClassName } color={ GlobalDangerColor100 }/>
+                <div className={ centerClassName }>Invalid condition</div>
+                <div className={ centerClassName }> { props.error } </div>
+            </>
+        );
+    }
+
+    return null;
+};
+
+const ConditionsStep: React.FunctionComponent = () => {
+    const context = React.useContext(WizardContext);
+    const { values } = useFormikContext<FormType>();
+
+    const triggerTestCondition = () => {
+        context.triggerAction(WizardActionType.VERIFY);
+    };
+
     return (
         <Form>
             <FormTextInput isRequired={ true } label="Condition text"
                 type="text" id="conditions" name="conditions"
-                placeholder={ 'arch = "x86_64"' }/>
+                placeholder={ 'arch = "x86_64"' }
+            />
+            <ActionGroup>
+                { values.conditions && values.conditions !== '' && (
+                    <>
+                        <Button onClick={ triggerTestCondition } variant={ ButtonVariant.secondary }>
+                            Test condition
+                        </Button>
+                        <ConditionStatus
+                            { ...context.verifyResponse }
+                            changed={ context.verifyResponse.conditions !== values.conditions }
+                        />
+                    </>
+                )}
+            </ActionGroup>
         </Form>
     );
 };
@@ -19,5 +82,12 @@ export const createConditionsStep: (stepOverrides?: Partial<WizardStepExtended>)
     name: 'Conditions',
     component: <ConditionsStep/>,
     validationSchema: PolicyFormConditions,
+    isContextValid: (context, values) => {
+        if (values.conditions === context.verifyResponse.conditions) {
+            return context.verifyResponse.isValid;
+        }
+
+        return false;
+    },
     ...stepOverrides
 });

--- a/src/components/Policy/WizardSteps/ConditionsStep.tsx
+++ b/src/components/Policy/WizardSteps/ConditionsStep.tsx
@@ -82,7 +82,7 @@ export const createConditionsStep: (stepOverrides?: Partial<WizardStepExtended>)
     name: 'Conditions',
     component: <ConditionsStep/>,
     validationSchema: PolicyFormConditions,
-    isContextValid: (context, values) => {
+    isValid: (context, values) => {
         if (values.conditions === context.verifyResponse.conditions) {
             return context.verifyResponse.isValid;
         }

--- a/src/components/Policy/WizardSteps/CreateCustomPolicyStep.tsx
+++ b/src/components/Policy/WizardSteps/CreateCustomPolicyStep.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Button, Form, InputGroup, Radio, TextInput } from '@patternfly/react-core';
 import { Policy } from '../../../types/Policy';
-import { AlwaysValid, WizardStepExtended } from './WizardStepExtended';
+import { AlwaysValid, WizardStepExtended } from '../PolicyWizardTypes';
 import { PolicyTable } from '../PolicyTable';
 import { useGetPoliciesQuery } from '../../../services/Api';
 

--- a/src/components/Policy/WizardSteps/DetailsStep.tsx
+++ b/src/components/Policy/WizardSteps/DetailsStep.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Form } from '@patternfly/react-core';
 
 import { FormTextInput } from '../../Formik/Patternfly';
-import { WizardStepExtended } from './WizardStepExtended';
+import { WizardStepExtended } from '../PolicyWizardTypes';
 import { PolicyFormDetails } from '../../../schemas/CreatePolicy/PolicySchema';
 
 const DetailsStep = () => {

--- a/src/components/Policy/WizardSteps/ReviewStep.tsx
+++ b/src/components/Policy/WizardSteps/ReviewStep.tsx
@@ -1,21 +1,20 @@
 import * as React from 'react';
 import { FieldArray, FieldArrayRenderProps } from 'formik';
 
-import { WizardStepExtended } from './WizardStepExtended';
+import { WizardContext, WizardStepExtended } from '../PolicyWizardTypes';
 import { FormTextInput, Switch } from '../../Formik/Patternfly';
 import { Form } from '@patternfly/react-core';
 import { ActionsForm } from '../ActionsForm';
 import { PolicyFormSchema } from '../../../schemas/CreatePolicy/PolicySchema';
+import { useContext } from 'react';
 
-export interface ReviewStepProps {
-    loading: boolean;
-}
-
-const ReviewStep: React.FunctionComponent<ReviewStepProps> = (props) => {
+const ReviewStep: React.FunctionComponent = () => {
+    const context = useContext(WizardContext);
 
     return (
         <>
             <Form>
+                <Switch isDisabled={ context.isLoading } type="checkbox" id="isEnabled" name="isEnabled" label="Activate Policy?"/>
                 <FormTextInput isReadOnly label="Name" type="text" name="name" id="name"/>
                 <FormTextInput isReadOnly label="Description" type="text" id="description" name="description"/>
                 <FormTextInput isReadOnly label="Condition text" type="text" id="conditions" name="conditions"/>
@@ -24,15 +23,14 @@ const ReviewStep: React.FunctionComponent<ReviewStepProps> = (props) => {
                         return <ActionsForm isReadOnly actions={ helpers.form.values.actions } arrayHelpers={ helpers }/>;
                     } }
                 </FieldArray>
-                <Switch isDisabled={ props.loading } type="checkbox" id="isEnabled" name="isEnabled" label="Activate Policy?"/>
             </Form>
         </>
     );
 };
 
-export const createReviewStep: (loading: boolean, stepOverrides?: Partial<WizardStepExtended>) => WizardStepExtended = (loading, stepOverrides) => ({
+export const createReviewStep: (stepOverrides?: Partial<WizardStepExtended>) => WizardStepExtended = (stepOverrides) => ({
     name: 'Review',
-    component: <ReviewStep loading={ loading }/>,
+    component: <ReviewStep/>,
     validationSchema: PolicyFormSchema,
     ...stepOverrides
 });

--- a/src/components/Policy/WizardSteps/WizardStepExtended.ts
+++ b/src/components/Policy/WizardSteps/WizardStepExtended.ts
@@ -1,9 +1,0 @@
-import * as Yup from 'yup';
-
-import { WizardStep } from '@patternfly/react-core';
-
-export type WizardStepExtended = WizardStep & {
-  validationSchema: Yup.Schema<unknown>;
-};
-
-export const AlwaysValid = Yup.object();

--- a/src/pages/ListPage/CreatePolicyWizard.tsx
+++ b/src/pages/ListPage/CreatePolicyWizard.tsx
@@ -1,25 +1,22 @@
 import * as React from 'react';
 import { PolicyWizard } from '../../components/Policy/PolicyWizard';
 import { Policy } from '../../types/Policy';
-import { useCreatePolicyMutation } from '../../services/Api';
+import { useCreatePolicyMutation, useVerifyPolicyMutation } from '../../services/Api';
 import * as HttpStatus from 'http-status-codes';
 import { addSuccessNotification, addDangerNotification } from '../../utils/AlertUtils';
+import { VerifyPolicyResponse } from '../../components/Policy/PolicyWizardTypes';
 
 interface CreatePolicyWizardProps {
     close: () => void;
     isOpen: boolean;
 }
 
-interface AlertProps {
-    variant: 'success' | 'danger';
-    title: string;
-}
-
 export const CreatePolicyWizard: React.FunctionComponent<CreatePolicyWizardProps> = (props) => {
-    const query = useCreatePolicyMutation();
+    const saveMutation = useCreatePolicyMutation();
+    const verifyMutation = useVerifyPolicyMutation();
 
     const onSave = (policy: Policy) => {
-        query.mutate(policy).then((res) => {
+        saveMutation.mutate(policy).then((res) => {
             switch (res.status) {
                 case HttpStatus.CREATED:
                     addSuccessNotification('Created', `Policy "${policy.name}" created`);
@@ -36,10 +33,36 @@ export const CreatePolicyWizard: React.FunctionComponent<CreatePolicyWizardProps
                     break;
                 case HttpStatus.INTERNAL_SERVER_ERROR:
                 default:
-                    addDangerNotification('Error', `An internal server error ocurred when processing Policy "${policy.name}"`);
+                    addDangerNotification('Error', `An internal server error occurred when processing Policy "${policy.name}"`);
             }
         });
     };
+
+    const onVerify = (policy: Policy): Promise<VerifyPolicyResponse> => {
+        return verifyMutation.mutate(policy).then((res) => {
+            switch (res.status) {
+                case HttpStatus.OK:
+                    return {
+                        isValid: true,
+                        conditions: policy.conditions
+                    };
+                case HttpStatus.BAD_REQUEST:
+                    return {
+                        isValid: false,
+                        error: res.payload.msg,
+                        conditions: policy.conditions
+                    };
+            }
+
+            return {
+                isValid: false,
+                error: res.payload || `Unknown Error when trying to validate: (Code ${res.status})`,
+                conditions: policy.conditions
+            };
+        });
+    };
+
+    const isLoading = saveMutation.loading || verifyMutation.loading;
 
     return (
         <>
@@ -48,7 +71,8 @@ export const CreatePolicyWizard: React.FunctionComponent<CreatePolicyWizardProps
                 initialValue={ { } }
                 onClose={ props.close }
                 onSave={ onSave }
-                isLoading={ query.loading }
+                onVerify={ onVerify }
+                isLoading={ isLoading }
             /> }
         </>
     );

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -56,5 +56,11 @@ export const useCreatePolicyMutation = () => {
     });
 };
 
+export const useVerifyPolicyMutation = () => {
+    return useMutation((policy: Policy) => {
+        return createAction('POST', urls.policies, { alsoStore: false }, toServerPolicy(policy));
+    });
+};
+
 export const useGetCustomerPolicyQuery = (policyId: string, initFetch?: boolean) =>
     useNewQuery<Policy>('GET', urls.customerPolicy(policyId), initFetch);

--- a/src/utils/PFColors.ts
+++ b/src/utils/PFColors.ts
@@ -1,0 +1,7 @@
+
+export const GlobalSuccessColor100 = '#92d400';
+export const GlobalSuccessColor200 = '#486b00';
+
+export const GlobalDangerColor100 = '#c9190b';
+export const GlobalDangerColor200 = '#a30000';
+export const GlobalDangerColor300 = '#470000';


### PR DESCRIPTION
 - Hooks a validation (Test condition) button for the
   conditions step that blocks until the conditions
   are valid.
 - Bug fix to the WizardPolicy, extracts FormikBinding
   Compontent to avoid re-creation on render, this caused
   several problems: unecesary renders, validations, and
   invalid state in the validations.

Also fixes CPOL-54 (because of the bug fix)

![test-condition](https://user-images.githubusercontent.com/3845764/73116466-755e0c80-3efc-11ea-912e-86c11115d38f.gif)

When the error is unknow, currently showing the response or if none: `Unknown Error when trying to validate: (Code ${res.status})`
![unknown-error](https://user-images.githubusercontent.com/3845764/73116467-755e0c80-3efc-11ea-8141-70c132f256f0.png)
