### PR TITLE
CPOL-79 Removes the Webhook action when in `beta`

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createClient, ClientContextProvider } from 'react-fetching-library';
+import { ClientContextProvider } from 'react-fetching-library';
 import { RouteComponentProps, withRouter } from 'react-router';
 import { NotificationsPortal } from '@redhat-cloud-services/frontend-components-notifications';
 
@@ -8,6 +8,7 @@ import { fetchRBAC } from '../utils/RbacUtils';
 import { RbacContext } from '../components/RbacContext';
 import { Routes } from '../Routes';
 import { AppSkeleton } from '../components/AppSkeleton/AppSkeleton';
+import { client } from './FetchingConfiguration';
 
 declare const insights: any;
 
@@ -49,7 +50,7 @@ const App: React.FunctionComponent<RouteComponentProps> = (props) => {
     }
 
     return (
-        <ClientContextProvider client={ createClient() }>
+        <ClientContextProvider client={ client }>
             <RbacContext.Provider value={ rbac }>
                 <NotificationsPortal/>
                 <Routes/>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -10,19 +10,12 @@ import { Routes } from '../Routes';
 import { AppSkeleton } from '../components/AppSkeleton/AppSkeleton';
 import { client } from './FetchingConfiguration';
 
-declare const insights: any;
-
-interface Account {
-    accountNumber: string;
-    username: string;
-}
-
 import '@redhat-cloud-services/frontend-components-notifications/index.css';
 import { Rbac } from '../types/Rbac';
+import insights from '../utils/Insights';
 
 const App: React.FunctionComponent<RouteComponentProps> = (props) => {
 
-    const [ , setAccount ] = React.useState<Account | undefined>(undefined);
     const [ rbac, setRbac ] = React.useState<Rbac | undefined>(undefined);
 
     React.useEffect(() => {
@@ -34,11 +27,7 @@ const App: React.FunctionComponent<RouteComponentProps> = (props) => {
     }, [ props.history ]);
 
     React.useEffect(() => {
-        insights.chrome.auth.getUser().then((userAccount: any) => {
-            setAccount({
-                accountNumber: userAccount.identity.account_number,
-                username: userAccount.identity.username
-            });
+        insights.chrome.auth.getUser().then(() => {
             fetchRBAC().then(setRbac);
         });
     }, []);

--- a/src/app/FetchingConfiguration.ts
+++ b/src/app/FetchingConfiguration.ts
@@ -1,6 +1,5 @@
 import { createClient, RequestInterceptor } from 'react-fetching-library';
-
-declare const insights: any;
+import insights from '../utils/Insights';
 
 const refreshAuthTokenInterceptor: RequestInterceptor = (_client) => (action) => {
     return insights.chrome.auth.getUser().then(() => action);

--- a/src/app/FetchingConfiguration.ts
+++ b/src/app/FetchingConfiguration.ts
@@ -1,0 +1,13 @@
+import { createClient, RequestInterceptor } from 'react-fetching-library';
+
+declare const insights: any;
+
+const refreshAuthTokenInterceptor: RequestInterceptor = (_client) => (action) => {
+    return insights.chrome.auth.getUser().then(() => action);
+};
+
+export const client = createClient({
+    requestInterceptors: [
+        refreshAuthTokenInterceptor
+    ]
+});

--- a/src/components/Policy/ActionsForm.tsx
+++ b/src/components/Policy/ActionsForm.tsx
@@ -15,6 +15,7 @@ import * as React from 'react';
 import { TimesIcon } from '@patternfly/react-icons';
 import { FormSelect } from '../Formik/Patternfly';
 import { ActionForm } from './ActionForm/ActionForm';
+import insights from '../../utils/Insights';
 
 interface ActionsFormProps {
     id: string;
@@ -45,7 +46,9 @@ export const ActionsForm: React.FunctionComponent<ActionsFormProps> = (props) =>
                         <CardBody className="pf-c-form">
                             <FormSelect isDisabled={ props.isReadOnly } id={ `actions.${index}.type` } name={ `actions.${index}.type` } label="Type">
                                 <FormSelectOption value="" label="Select an Action type"/>
-                                { Object.values(ActionType).map(type => <FormSelectOption
+                                { Object.values(ActionType)
+                                .filter(actionType => insights.chrome.isBeta() || actionType !== ActionType.WEBHOOK)
+                                .map(type => <FormSelectOption
                                     key={ type }
                                     label={ capitalize(type) }
                                     value={ type }/>)}

--- a/src/utils/Insights.ts
+++ b/src/utils/Insights.ts
@@ -1,0 +1,54 @@
+// This type was fetched by manual inspection and is incomplete.
+// Check in your browser the `insights` global for more information.
+// Is possible that there is something wrong and/or missing, but as I was using this on more than one file it seems like
+// a good idea to have all the usage in a single file and define a common interface to keep track of it.
+// It would be even better to add the typings to the common code or to @types.
+
+interface Entitlement {
+    is_entitle: boolean;
+}
+
+interface UserData {
+    username: string;
+    email: string;
+    first_name: string;
+    last_name: string;
+    is_active: boolean;
+    is_org_admin: boolean;
+    is_internal: boolean;
+    locale: string;
+}
+
+interface Internal {
+    org_id: string;
+    account_id: string;
+}
+
+interface Identity {
+    account_number: string;
+    type: string;
+    user: UserData;
+    internal: Internal;
+}
+
+interface User {
+    identity: Identity;
+    entitlements: Record<string, Entitlement>;
+}
+
+type InsightsType = {
+    chrome: {
+        init: () => void;
+        identifyApp: (appId: string) => Promise<void>;
+        on: (type: string, callback: ((event: any) => void)) => void;
+        auth: {
+            getUser: () => Promise<User>;
+        };
+        isProd: boolean;
+        isBeta: () => boolean;
+    };
+};
+
+declare const insights: InsightsType;
+
+export default insights;


### PR DESCRIPTION
Depends on #39, Updated part of that code to use the Insights type.

### In beta
![hook-in-beta](https://user-images.githubusercontent.com/3845764/74182930-92d3eb80-4c09-11ea-9a5c-81dfb275a208.png)

### Not in beta
![hook-not-in-beta](https://user-images.githubusercontent.com/3845764/74182958-a3846180-4c09-11ea-9b5c-4117f3e0beb0.png)
