### PR TITLE
Ensure `insights` var binds correctly

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -12,23 +12,29 @@ import { client } from './FetchingConfiguration';
 
 import '@redhat-cloud-services/frontend-components-notifications/index.css';
 import { Rbac } from '../types/Rbac';
-import insights from '../utils/Insights';
+import { getInsights } from '../utils/Insights';
 
 const App: React.FunctionComponent<RouteComponentProps> = (props) => {
 
     const [ rbac, setRbac ] = React.useState<Rbac | undefined>(undefined);
 
     React.useEffect(() => {
-        insights.chrome.init();
-        insights.chrome.identifyApp(Config.appId);
+        getInsights().then((insights) => {
+            insights.chrome.init();
+            insights.chrome.identifyApp(Config.appId);
+        });
         return () => {
-            insights.chrome.on('APP_NAVIGATION', (event: any) => props.history.push(`/${event.navId}`));
+            getInsights().then((insights) => {
+                insights.chrome.on('APP_NAVIGATION', (event: any) => props.history.push(`/${event.navId}`));
+            });
         };
     }, [ props.history ]);
 
     React.useEffect(() => {
-        insights.chrome.auth.getUser().then(() => {
-            fetchRBAC().then(setRbac);
+        getInsights().then(insights => {
+            insights.chrome.auth.getUser().then(() => {
+                fetchRBAC().then(setRbac);
+            });
         });
     }, []);
 

--- a/src/app/FetchingConfiguration.ts
+++ b/src/app/FetchingConfiguration.ts
@@ -1,8 +1,10 @@
 import { createClient, RequestInterceptor } from 'react-fetching-library';
-import insights from '../utils/Insights';
+import { getInsights } from '../utils/Insights';
 
 const refreshAuthTokenInterceptor: RequestInterceptor = (_client) => (action) => {
-    return insights.chrome.auth.getUser().then(() => action);
+    return getInsights()
+    .then(insights => insights.chrome.auth.getUser())
+    .then(() => action);
 };
 
 export const client = createClient({

--- a/src/components/Policy/ActionsForm.tsx
+++ b/src/components/Policy/ActionsForm.tsx
@@ -15,7 +15,7 @@ import * as React from 'react';
 import { TimesIcon } from '@patternfly/react-icons';
 import { FormSelect } from '../Formik/Patternfly';
 import { ActionForm } from './ActionForm/ActionForm';
-import insights from '../../utils/Insights';
+import { getInsights } from '../../utils/Insights';
 
 interface ActionsFormProps {
     id: string;
@@ -47,7 +47,7 @@ export const ActionsForm: React.FunctionComponent<ActionsFormProps> = (props) =>
                             <FormSelect isDisabled={ props.isReadOnly } id={ `actions.${index}.type` } name={ `actions.${index}.type` } label="Type">
                                 <FormSelectOption value="" label="Select an Action type"/>
                                 { Object.values(ActionType)
-                                .filter(actionType => insights.chrome.isBeta() || actionType !== ActionType.WEBHOOK)
+                                .filter(async actionType => (await getInsights()).chrome.isBeta() || actionType !== ActionType.WEBHOOK)
                                 .map(type => <FormSelectOption
                                     key={ type }
                                     label={ capitalize(type) }

--- a/src/utils/Insights.ts
+++ b/src/utils/Insights.ts
@@ -51,4 +51,14 @@ type InsightsType = {
 
 declare const insights: InsightsType;
 
-export default insights;
+const insightPromise: Promise<InsightsType> = new Promise<InsightsType>(async (resolve) => {
+    while (!window.hasOwnProperty('insights')) {
+        await new Promise(timeout => setTimeout(timeout, 250));
+    }
+
+    resolve(insights);
+});
+
+export const getInsights = (): Promise<InsightsType> => {
+    return insightPromise;
+};


### PR DESCRIPTION
 - Using a promise to ensure we have a value before resolving

Without this, we intermittently get between loads "insights is not defined" error in the console.